### PR TITLE
Check For Illegal Fixed Addr

### DIFF
--- a/xv6-public/sysfile.c
+++ b/xv6-public/sysfile.c
@@ -522,11 +522,6 @@ int sys_mmap(void)
 
       // if the requested mapping is before the next VMA
       if(arg_addr < curr_vma.next->start){
-        // if the requested allocation encroaches on the next VMA
-        if(arg_addr+length >= curr_vma.next->start) {
-          return -1;
-        }
-
         // check the space after it
         if(curr_vma.space_after > length) {
           // we found enough space


### PR DESCRIPTION
Added logic to check for an address encroaching on the next VMA. This only matters if the address is fixed, otherwise the simple check of comparing the scalar values of the requested length to the space after is good enough. 

Also, made a sanity check change with the address being recorded as the start address when MAP_FIXED is not set.